### PR TITLE
Updated add.php

### DIFF
--- a/concrete/blocks/autonav/add.php
+++ b/concrete/blocks/autonav/add.php
@@ -1,6 +1,6 @@
 <?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 
 <?php
-$info = array();
-$view->inc('form_setup_html.php', array('info' => $info, 'c' => $c));
+$info = $controller->getContent();
+$view->inc('form_setup_html.php', array('info' => $info));
 ?>


### PR DESCRIPTION
Adding autonav block didn't work, since the $info variable passed to the form_setup_html.php from add.php was an empty array.
$c variable passed to the form_setup_html.php was not initialized in the app.php.

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above  

- [x] PHP-only files follow our coding style; in order to do that use php-cs-fixer - http://cs.sensiolabs.org/ - as follows:
  `php-cs-fixer fix --config=<webroot>/.php_cs.dist <filename>`

If all the above conditions are met, feel free to delete this whole message and to submit your pull request, and... Thank you, your help is really appreciated!